### PR TITLE
Update linter config

### DIFF
--- a/cdk/.editorconfig
+++ b/cdk/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/cdk/.eslintignore
+++ b/cdk/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+cdk.out
+.eslintrc.js
+jest.config.js

--- a/cdk/.eslintrc.js
+++ b/cdk/.eslintrc.js
@@ -1,20 +1,20 @@
 module.exports = {
+  root: true,
   env: {
-    browser: false,
-    es2021: true,
+    node: true,
+    jest: true,
   },
-  extends: "@guardian/eslint-config-typescript",
-  parser: "@typescript-eslint/parser",
+  extends: ["@guardian/eslint-config-typescript"],
   parserOptions: {
-    ecmaVersion: 12,
+    ecmaVersion: 2020,
     tsconfigRootDir: __dirname,
     sourceType: "module",
+    project: ["./tsconfig.eslint.json"],
   },
   plugins: ["@typescript-eslint"],
   rules: {
     "@typescript-eslint/no-inferrable-types": 0,
     "import/no-namespace": 2,
   },
-  root: true,
   ignorePatterns: ["**/*.js", "node_modules"],
 };

--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -1,7 +1,9 @@
 *.js
 !jest.config.js
+!eslintrc.js
 *.d.ts
 node_modules
+dist
 
 # CDK asset staging directory
 .cdk.staging

--- a/cdk/.npmignore
+++ b/cdk/.npmignore
@@ -1,6 +1,0 @@
-*.ts
-!*.d.ts
-
-# CDK asset staging directory
-.cdk.staging
-cdk.out

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import "source-map-support/register";
-import { CdkStack } from "../lib/cdk-stack";
 import { App } from "@aws-cdk/core";
+import { CdkStack } from "../lib/cdk-stack";
 
 const app = new App();
 new CdkStack(app, "CdkStack");

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -9,7 +9,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "lint": "eslint lib --ext .ts"
+    "lint": "eslint lib/** bin/** --ext .ts"
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.74.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
+    "format": "prettier --write \"{lib,bin}/**/*.ts\"",
     "cdk": "cdk",
     "lint": "eslint lib/** bin/** --ext .ts"
   },

--- a/cdk/tsconfig.eslint.json
+++ b/cdk/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["lib/**/*", "bin/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -1,12 +1,19 @@
 {
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  },
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": ["es2018"],
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "esModuleInterop": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
     "noUnusedLocals": false,
@@ -17,7 +24,14 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "outDir": "dist"
   },
-  "exclude": ["cdk.out"]
+  "include": ["lib/**/*", "bin/**/*"],
+  "exclude": [
+    "node_modules",
+    "cdk.out",
+    "lib/**/*.test.ts",
+    "lib/**/__snapshots__/**"
+  ]
 }


### PR DESCRIPTION
## What does this change?

Currently the configuration for eslint config, editor config and ts config are different between the repositories that have been migrated to make use of the `@guardian/cdk` library. This PR updates the config here to be consistent with the first migrated repo. 

## How to test

n/a

## How can we measure success?

The `cdk` config is consistent across repositories.

## Have we considered potential risks?

n/a

## Images

n/a
