### PR TITLE
Bump @guardian/cdk version

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -4,4 +4,4 @@ import { App } from "@aws-cdk/core";
 import { CdkStack } from "../lib/cdk-stack";
 
 const app = new App();
-new CdkStack(app, "CdkStack");
+new CdkStack(app, "CdkStack", { app: "tag-janitor" });

--- a/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
@@ -108,6 +108,10 @@ Object {
         "Runtime": "nodejs12.x",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "tag-janitor",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -148,6 +152,10 @@ Object {
           },
         ],
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "tag-janitor",
+          },
           Object {
             "Key": "Stack",
             "Value": Object {
@@ -209,6 +217,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "tag-janitor",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -229,6 +241,47 @@ Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "BucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "BucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
               "Action": "SNS:Publish",
               "Effect": "Allow",
               "Resource": Object {
@@ -247,7 +300,26 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "tagjanitorlambdatagjanitorlambda7days250DED67": Object {
+    "tagjanitorlambdatagjanitorlambdarate7days0AllowEventRuletagjanitortagjanitorlambdatagjanitorlambdarate7days03288E20D8CA3ECD4": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "tagjanitorlambda3E6E11A1",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "tagjanitorlambdatagjanitorlambdarate7days0B5F68379",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "tagjanitorlambdatagjanitorlambdarate7days0B5F68379": Object {
       "Properties": Object {
         "Description": "Run tag-janitor every 7 days",
         "ScheduleExpression": "rate(7 days)",
@@ -265,25 +337,6 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "tagjanitorlambdatagjanitorlambda7daysAllowEventRuletagjanitortagjanitorlambdatagjanitorlambda7days9D698530D511210C": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "tagjanitorlambda3E6E11A1",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::GetAtt": Array [
-            "tagjanitorlambdatagjanitorlambda7days250DED67",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
     },
   },
 }

--- a/cdk/lib/cdk-stack.test.ts
+++ b/cdk/lib/cdk-stack.test.ts
@@ -5,7 +5,7 @@ import { CdkStack } from "./cdk-stack";
 describe("The tag-janitor stack", () => {
   it("matches the snapshot", () => {
     const app = new App();
-    const stack = new CdkStack(app, "tag-janitor");
+    const stack = new CdkStack(app, "tag-janitor", { app: "tag-janitor" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -39,7 +39,7 @@
     "@aws-cdk/aws-lambda": "1.74.0",
     "@aws-cdk/aws-s3": "1.74.0",
     "@aws-cdk/core": "1.74.0",
-    "@guardian/cdk": "^0.1.0",
+    "@guardian/cdk": "^0.3.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -22,7 +22,7 @@
     "@aws-cdk/cx-api" "1.74.0"
     constructs "^3.2.0"
 
-"@aws-cdk/aws-apigateway@1.74.0":
+"@aws-cdk/aws-apigateway@1.74.0", "@aws-cdk/aws-apigateway@~1.74.0":
   version "1.74.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.74.0.tgz#17a0771c2129520f8ca7c922b08a5b386f2989e1"
   integrity sha512-kSwZJ7eVo6qmOsfxN4LRIwmNpiOBxsEzswVcJnyeKPMfD2KRj/UGZp6hDeoj4Mf734RXiH4qLUlrtjrcSP1vTw==
@@ -336,7 +336,7 @@
     "@aws-cdk/region-info" "1.74.0"
     constructs "^3.2.0"
 
-"@aws-cdk/aws-events-targets@1.74.0":
+"@aws-cdk/aws-events-targets@1.74.0", "@aws-cdk/aws-events-targets@~1.74.0":
   version "1.74.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.74.0.tgz#a88f1c50ead14aecd5270a11ea7b3639fef72f5c"
   integrity sha512-9xEY59aTNbsMmXLchpeX4qgIm8Ggh+PpzPxVH/s9wQM2i40lInQOZgs0wJPGMHY7Y8gVTu2uVsyrchPeXVuUQw==
@@ -404,7 +404,7 @@
     "@aws-cdk/core" "1.74.0"
     constructs "^3.2.0"
 
-"@aws-cdk/aws-lambda@1.74.0":
+"@aws-cdk/aws-lambda@1.74.0", "@aws-cdk/aws-lambda@~1.74.0":
   version "1.74.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.74.0.tgz#52175fbc9e679ca5c0f4d15e0666c99fc4a953d0"
   integrity sha512-Ju3/mhnli33xnO2qvJUs11djva12SHnmJPGtbx4Nz33z577/pCwLZYWa7noP8eUzAyBglfNlPG8JWH+fNHPbew==
@@ -495,7 +495,7 @@
     "@aws-cdk/cx-api" "1.74.0"
     constructs "^3.2.0"
 
-"@aws-cdk/aws-s3@1.74.0":
+"@aws-cdk/aws-s3@1.74.0", "@aws-cdk/aws-s3@~1.74.0":
   version "1.74.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.74.0.tgz#5b53839c3af0f67bfb1e96061f6a1ea5be445fe9"
   integrity sha512-xbRbI90hUvmVwGHHMr4dPWv0TXBxr/HeeaLzqLDHv36+TKA0wMR7ttRm3pbT3Kf/YjqSty788rom6lVqaAu81Q==
@@ -961,17 +961,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-0.1.0.tgz#dde10620cc4c9b97555ee1ccfb77027d5b9e1bdc"
-  integrity sha512-fmZG3ed5ZlDW2OsR3kkWPSZcyNN1ilF2li41xiFMD5vrUKqxeTWUkwOLkwWH3qlhU6Dw1SQhwcaNsnegkGsABA==
+"@guardian/cdk@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-0.3.0.tgz#4644d27ba5ff646a8952b996f4f286431ab324cb"
+  integrity sha512-rtXCHVoyRHMhdADX2W4H9Dt3K/rIrymBKsNfBQLiOMcbC0+raH6XHGojSMOfAIdOvr4SfppRZmgasw/DtV1DHg==
   dependencies:
     "@aws-cdk/assert" "~1.74.0"
+    "@aws-cdk/aws-apigateway" "~1.74.0"
     "@aws-cdk/aws-autoscaling" "~1.74.0"
     "@aws-cdk/aws-ec2" "~1.74.0"
     "@aws-cdk/aws-elasticloadbalancingv2" "~1.74.0"
+    "@aws-cdk/aws-events-targets" "~1.74.0"
     "@aws-cdk/aws-iam" "~1.74.0"
+    "@aws-cdk/aws-lambda" "~1.74.0"
     "@aws-cdk/aws-rds" "~1.74.0"
+    "@aws-cdk/aws-s3" "~1.74.0"
     "@aws-cdk/core" "~1.74.0"
 
 "@guardian/eslint-config-typescript@^0.4.1":


### PR DESCRIPTION
## What does this change?

This PR updates the version of `@guardian/cdk` to 0.3.0 and fixes the breaking changes, namely:

* lambda frequency is now provided as a schedule
* app is now passed as a prop to GuStack
* stack and stage are available from the stack as strings

## How to test

Check the updated snapshot file to see the changes and run the test suite to confirm it passes.

## How can we measure success?

Tag Janitor uses the latest and greatest features of `@guardian/cdk`

## Have we considered potential risks?

n/a

## Images

n/a
