### PR TITLE
Add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# See the documentation for all configuration options https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/lambda'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/cdk'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## What does this change?

This PR adds a `dependabot.yml` file to the repo to help to keep the project dependencies in sync. It is configured to monitor the GitHub Actions as well as the node modules in both the `cdk` and `lambda` directories.

## How to test

Wait for dependabot to start opening PRs.

## How can we measure success?

The project uses the most up to date dependencies