### PR TITLE
Fix handler path

### DIFF
--- a/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
@@ -97,7 +97,7 @@ Object {
             ],
           ],
         },
-        "Handler": "dist/handler.handler",
+        "Handler": "dist/src/handler.handler",
         "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -36,7 +36,7 @@ export class CdkStack extends GuStack {
     const lambdaFrequency = Duration.days(7);
 
     const tagJanitorLambda = new GuLambdaFunction(this, `${this.app}-lambda`, {
-      handler: "dist/handler.handler",
+      handler: "dist/src/handler.handler",
       functionName: `${this.app}-${this.stage}`,
       runtime: Runtime.NODEJS_12_X,
       code: {


### PR DESCRIPTION
## What does this change?

This lambda has been failing to run successfully for several weeks due to a broken handler configuration:

```Uncaught Exception 	{"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'handler'\nRequire stack:\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js","stack":["Runtime.ImportModuleError: Error: Cannot find module 'handler'","Require stack:","- /var/runtime/UserFunction.js","- /var/runtime/index.js","    at _loadUserApp (/var/runtime/UserFunction.js:100:13)","    at Object.module.exports.load (/var/runtime/UserFunction.js:140:17)","    at Object.<anonymous> (/var/runtime/index.js:43:30)","    at Module._compile (internal/modules/cjs/loader.js:999:30)","    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)","    at Module.load (internal/modules/cjs/loader.js:863:32)","    at Function.Module._load (internal/modules/cjs/loader.js:708:14)","    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)","    at internal/main/run_main_module.js:17:47"]}```

This PR should fix the problem.

## How to test

Since things were already pretty broken, I deployed this branch to `PROD`* and [confirmed that the lambda now runs successfully](https://logs.gutools.co.uk/s/devx/goto/f0206f8d48fed21e54f0132698063f33).

*Unfortunately there doesn't seem to be a `CODE` environment.

## How can we measure success?

The lambda should run successfully the next time it is invoked (by the CloudWatch rule).