### PR TITLE
Add alert based on error % of lambda

### DIFF
--- a/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
@@ -45,6 +45,115 @@ Object {
     },
   },
   "Resources": Object {
+    "errorpercentagealarmforscheduledlambdaF6DA7824": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":jacob-testing",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "tagjanitorlambda3E6E11A1",
+              },
+              " exceeded 99% error rate",
+            ],
+          ],
+        },
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "High error % from ",
+              Object {
+                "Ref": "tagjanitorlambda3E6E11A1",
+              },
+              " lambda in ",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "Error % of ",
+                  Object {
+                    "Ref": "tagjanitorlambda3E6E11A1",
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "tagjanitorlambda3E6E11A1",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "tagjanitorlambda3E6E11A1",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 99,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "tagjanitorlambda3E6E11A1": Object {
       "DependsOn": Array [
         "tagjanitorlambdaServiceRoleDefaultPolicy79766902",

--- a/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-stack.test.ts.snap
@@ -60,7 +60,7 @@ Object {
                 Object {
                   "Ref": "AWS::AccountId",
                 },
-                ":jacob-testing",
+                ":devx-alerts",
               ],
             ],
           },

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -50,7 +50,10 @@ export class CdkStack extends GuStack {
         subnets: GuVpc.subnetsfromParameter(this),
       },
       schedule: Schedule.rate(lambdaFrequency),
-      monitoringConfiguration: { noMonitoring: true },
+      monitoringConfiguration: {
+        snsTopicName: "jacob-testing",
+        toleratedErrorPercentage: 99,
+      },
     });
 
     tagJanitorLambda.addToRolePolicy(

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -51,7 +51,7 @@ export class CdkStack extends GuStack {
       },
       schedule: Schedule.rate(lambdaFrequency),
       monitoringConfiguration: {
-        snsTopicName: "jacob-testing",
+        snsTopicName: "devx-alerts",
         toleratedErrorPercentage: 99,
       },
     });


### PR DESCRIPTION
## What does this change?

This PR adds an alert so that the team are notified if the Tag Janitor lambda fails consistently.

## How to test

N/A - this alert configuration was tested as part of https://github.com/guardian/cdk/pull/186#issue-559020689.

## How can we measure success?

If we break the Tag Janitor lambda, the team should receive an alert.

## Have we considered potential risks?

I've chosen to tolerate a very high % of errors - this alert will only fire if the lambda fails 100% of the time during a five minute period. This lambda is invoked [asynchronously](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html), which means that AWS will retry a couple of times upon experiencing a failure. Consequently we should only receive alerts if/when there are consistent failures.

This is useful because it means we _shouldn't_ get an alarm if there are transient failures (e.g. HTTP request to Prism times out) that do no require action. However, it's possible that this configuration will lead to us missing subtle bugs / edge cases which only cause occasional failures. 