### PR TITLE
Remove TeamCity condition

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,16 +2,10 @@
 
 set -e
 
-if [[ ! -z "${TEAMCITY_VERSION}" ]]; then
-  echo "Running in TeamCity. Nope!"
-  exit 0
-fi
-
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${DIR}/.."
 
 CDK_OUTPUT_DIR="${ROOT_DIR}/cloudformation/cdk"
-
 
 (
   cd "${ROOT_DIR}/cdk"


### PR DESCRIPTION
#213 has successfully been merged and tested end to end and we can now move away from TeamCity entirely. I've paused the build in the UI and this change simplifies the CI script.