### PR TITLE
ci: Use composite GHA provided by GuCDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: guardian/actions-assume-aws-role@v1.0.0
         with:
           awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+      - uses: guardian/cdk@aa-composite-action
+        with:
+          packageManager: yarn
+          lockfile: cdk/yarn.lock
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.4.0
         with:

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
     "cdk": "cdk",
-    "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern"
+    "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
+    "synth": "cdk synth --path-metadata false --version-reporting false --output ../cloudformation/cdk"
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.120.0",

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,16 +5,6 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${DIR}/.."
 
-CDK_OUTPUT_DIR="${ROOT_DIR}/cloudformation/cdk"
-
-(
-  cd "${ROOT_DIR}/cdk"
-   yarn --frozen-lockfile
-   yarn lint
-   yarn test
-   yarn cdk synth -o "${CDK_OUTPUT_DIR}"
-)
-
 (
   cd "${ROOT_DIR}/lambda"
   yarn --frozen-lockfile


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This replaces the portion of CI for CDK with a composite action provided by the guardian/cdk repository in https://github.com/guardian/cdk/pull/871.

The impact is a reduction of boilerplate.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should continue to work as before. That is, an artifact should be available to Riff-Raff to deploy and the artifact should contain a JSON CloudFormation template generated from CDK.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Less boilerplate.
