### PR TITLE
Use aws-actions/configure-aws-credentials instead of guardian/actions-assume-aws-role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ jobs:
         node-version: [14.15.1]
     steps:
       - uses: actions/checkout@v2
-      - uses: guardian/actions-assume-aws-role@v1.0.0
+      - uses: aws-actions/configure-aws-credentials@v1
         with:
-          awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.4.0
         with:


### PR DESCRIPTION
## What does this change?

We developed https://github.com/guardian/actions-assume-aws-role to support the migration to GitHub Actions (more specifically, it allowed us to upload build artifacts to Riff-Raff's S3 buckets without using permanent credentials).

There is now an official action (maintained by AWS) which offers this functionality - https://github.com/aws-actions/configure-aws-credentials. This PR switches to using the AWS alternative instead of the (now deprecated) Guardian action. 

Related PRs:
https://github.com/guardian/actions-assume-aws-role/pull/80
https://github.com/guardian/node-riffraff-artifact/pull/33
https://github.com/guardian/sbt-riffraff-artifact/pull/69