### PR TITLE
move cdk dependencies to devDependencies

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -23,9 +23,7 @@
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
-    "typescript": "~4.4.2"
-  },
-  "dependencies": {
+    "typescript": "~4.4.2",
     "@aws-cdk/assert": "1.120.0",
     "@aws-cdk/aws-ec2": "1.120.0",
     "@aws-cdk/aws-events-targets": "1.120.0",


### PR DESCRIPTION
## What does this change?

This moves the cdk dependencies for this project into devDependencies.
This brings the structure of the package.json into line with other projects using cdk.
Due to its complexity, work to update cdk to the current version will be tackled in a seperate card

No changes to functionality.